### PR TITLE
Make DbOpenHelper a Singleton

### DIFF
--- a/app/src/main/java/uk/co/ribot/androidboilerplate/data/local/DbOpenHelper.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/data/local/DbOpenHelper.java
@@ -5,9 +5,11 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import uk.co.ribot.androidboilerplate.injection.ApplicationContext;
 
+@Singleton
 public class DbOpenHelper extends SQLiteOpenHelper {
 
     public static final String DATABASE_NAME = "ribots.db";


### PR DESCRIPTION
DbOpenHelper should be a Singleton because it's a subclass of SQLiteOpenHelper, of which there should be only one instance.

If there are multiple instances of SQLiteOpenHelper, the synchronized (this) blocks in SQLiteOpenHelper don't do their job, since `this` is the SQLiteOpenHelper instance, so each instance will use different locks. This is bad because we need to use a single lock for the entire database to prevent race conditions.

More info: https://www.google.com/search?q=sqliteopenhelper+multiple+instances
